### PR TITLE
Cells are re-enabled if they are representing an in-month day

### DIFF
--- a/src/XamarinFormsCalendar/XamarinFormsCalendar/View/CalendarView.xaml
+++ b/src/XamarinFormsCalendar/XamarinFormsCalendar/View/CalendarView.xaml
@@ -25,7 +25,7 @@
 						  	InputTransparent="true"/>
 				
 				<DatePicker x:Name="CalendarDatePicker"
-							Date="{Binding Source={x:Reference this}, Path=CurrentDate, Mode=TwoWay}"
+							Date="{Binding Source={x:Reference this}, Path=SelectedDate, Mode=TwoWay}"
 							HorizontalOptions="FillAndExpand"
 							Grid.Column="1"
 							Opacity="0"


### PR DESCRIPTION
Previously, cells were left disabled meaning they would no longer be available to interact with.

Selected date is now used for the date chosen by the user, date picker is bound to this property. Current Date is used to show the current month (on-screen date).

Perhaps CurrentDate should refactored as DisplayDate?